### PR TITLE
Live Refresh Markdown Preview

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 
 # Mark the database schema as having been generated.
 db/schema.rb linguist-generated
+yarn.lock linguist-generated
 
 # Mark any vendored files as having been vendored.
 vendor/* linguist-vendored

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,9 @@ gem "omniauth-github"
 gem "octokit"
 gem "octicons_helper"
 
+gem "redcarpet", "~> 3.6"
+gem "rouge", "~> 4.1"
+
 group :development, :test do
   gem "pry-byebug"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,8 +198,10 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
+    redcarpet (3.6.0)
     regexp_parser (2.7.0)
     rexml (3.2.5)
+    rouge (4.1.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sawyer (0.9.2)
@@ -264,6 +266,8 @@ DEPENDENCIES
   pry-byebug
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.2)
+  redcarpet (~> 3.6)
+  rouge (~> 4.1)
   selenium-webdriver
   sprockets-rails
   sqlite3 (~> 1.4)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_tree ../builds
+//= link_tree ../stylesheets

--- a/app/assets/stylesheets/dracula.css
+++ b/app/assets/stylesheets/dracula.css
@@ -1,0 +1,91 @@
+/* Dracula Theme v1.2.5
+ *
+ * https://github.com/zenorocha/dracula-theme
+ *
+ * Copyright 2016, All rights reserved
+ *
+ * Code licensed under the MIT license
+ * http://zenorocha.mit-license.org
+ *
+ * @author Rob G <wowmotty@gmail.com>
+ * @author Chris Bracco <chris@cbracco.me>
+ * @author Zeno Rocha <hi@zenorocha.com>
+ */
+
+.highlight .hll { background-color: #f1fa8c }
+.highlight  { background: #282a36; color: #f8f8f2 }
+.highlight .c { color: #6272a4 } /* Comment */
+.highlight .err { color: #f8f8f2 } /* Error */
+.highlight .g { color: #f8f8f2 } /* Generic */
+.highlight .k { color: #ff79c6 } /* Keyword */
+.highlight .l { color: #f8f8f2 } /* Literal */
+.highlight .n { color: #f8f8f2 } /* Name */
+.highlight .o { color: #ff79c6 } /* Operator */
+.highlight .x { color: #f8f8f2 } /* Other */
+.highlight .p { color: #f8f8f2 } /* Punctuation */
+.highlight .ch { color: #6272a4 } /* Comment.Hashbang */
+.highlight .cm { color: #6272a4 } /* Comment.Multiline */
+.highlight .cp { color: #ff79c6 } /* Comment.Preproc */
+.highlight .cpf { color: #6272a4 } /* Comment.PreprocFile */
+.highlight .c1 { color: #6272a4 } /* Comment.Single */
+.highlight .cs { color: #6272a4 } /* Comment.Special */
+.highlight .gd { color: #8b080b } /* Generic.Deleted */
+.highlight .ge { color: #f8f8f2; text-decoration: underline } /* Generic.Emph */
+.highlight .gr { color: #f8f8f2 } /* Generic.Error */
+.highlight .gh { color: #f8f8f2; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #f8f8f2; font-weight: bold } /* Generic.Inserted */
+.highlight .go { color: #44475a } /* Generic.Output */
+.highlight .gp { color: #f8f8f2 } /* Generic.Prompt */
+.highlight .gs { color: #f8f8f2 } /* Generic.Strong */
+.highlight .gu { color: #f8f8f2; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #f8f8f2 } /* Generic.Traceback */
+.highlight .kc { color: #ff79c6 } /* Keyword.Constant */
+.highlight .kd { color: #8be9fd; font-style: italic } /* Keyword.Declaration */
+.highlight .kn { color: #ff79c6 } /* Keyword.Namespace */
+.highlight .kp { color: #ff79c6 } /* Keyword.Pseudo */
+.highlight .kr { color: #ff79c6 } /* Keyword.Reserved */
+.highlight .kt { color: #8be9fd } /* Keyword.Type */
+.highlight .ld { color: #f8f8f2 } /* Literal.Date */
+.highlight .m { color: #bd93f9 } /* Literal.Number */
+.highlight .s { color: #f1fa8c } /* Literal.String */
+.highlight .na { color: #50fa7b } /* Name.Attribute */
+.highlight .nb { color: #8be9fd; font-style: italic } /* Name.Builtin */
+.highlight .nc { color: #50fa7b } /* Name.Class */
+.highlight .no { color: #f8f8f2 } /* Name.Constant */
+.highlight .nd { color: #f8f8f2 } /* Name.Decorator */
+.highlight .ni { color: #f8f8f2 } /* Name.Entity */
+.highlight .ne { color: #f8f8f2 } /* Name.Exception */
+.highlight .nf { color: #50fa7b } /* Name.Function */
+.highlight .nl { color: #8be9fd; font-style: italic } /* Name.Label */
+.highlight .nn { color: #f8f8f2 } /* Name.Namespace */
+.highlight .nx { color: #f8f8f2 } /* Name.Other */
+.highlight .py { color: #f8f8f2 } /* Name.Property */
+.highlight .nt { color: #ff79c6 } /* Name.Tag */
+.highlight .nv { color: #8be9fd; font-style: italic } /* Name.Variable */
+.highlight .ow { color: #ff79c6 } /* Operator.Word */
+.highlight .w { color: #f8f8f2 } /* Text.Whitespace */
+.highlight .mb { color: #bd93f9 } /* Literal.Number.Bin */
+.highlight .mf { color: #bd93f9 } /* Literal.Number.Float */
+.highlight .mh { color: #bd93f9 } /* Literal.Number.Hex */
+.highlight .mi { color: #bd93f9 } /* Literal.Number.Integer */
+.highlight .mo { color: #bd93f9 } /* Literal.Number.Oct */
+.highlight .sa { color: #f1fa8c } /* Literal.String.Affix */
+.highlight .sb { color: #f1fa8c } /* Literal.String.Backtick */
+.highlight .sc { color: #f1fa8c } /* Literal.String.Char */
+.highlight .dl { color: #f1fa8c } /* Literal.String.Delimiter */
+.highlight .sd { color: #f1fa8c } /* Literal.String.Doc */
+.highlight .s2 { color: #f1fa8c } /* Literal.String.Double */
+.highlight .se { color: #f1fa8c } /* Literal.String.Escape */
+.highlight .sh { color: #f1fa8c } /* Literal.String.Heredoc */
+.highlight .si { color: #f1fa8c } /* Literal.String.Interpol */
+.highlight .sx { color: #f1fa8c } /* Literal.String.Other */
+.highlight .sr { color: #f1fa8c } /* Literal.String.Regex */
+.highlight .s1 { color: #f1fa8c } /* Literal.String.Single */
+.highlight .ss { color: #f1fa8c } /* Literal.String.Symbol */
+.highlight .bp { color: #f8f8f2; font-style: italic } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #50fa7b } /* Name.Function.Magic */
+.highlight .vc { color: #8be9fd; font-style: italic } /* Name.Variable.Class */
+.highlight .vg { color: #8be9fd; font-style: italic } /* Name.Variable.Global */
+.highlight .vi { color: #8be9fd; font-style: italic } /* Name.Variable.Instance */
+.highlight .vm { color: #8be9fd; font-style: italic } /* Name.Variable.Magic */
+.highlight .il { color: #bd93f9 } /* Literal.Number.Integer.Long */

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,15 +1,70 @@
 class IssuesController < ApplicationController
-  before_action :set_issue, only: [:edit]
+  before_action :set_document
+
+  ChangeSet = Struct.new(:from_a, :to_a, :from_b, :to_b, :inserted)
 
   def edit
   end
 
-  private
+  def update
+    @document.apply(change_set)
+    @document.save!
 
-  def set_issue
-    @issue = Issue.new(github.issue(repo, issue_params[:issue_number]))
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace("preview_card", partial: "issues/card")
+      end
+    end
   end
 
-  def repo = "#{issue_params[:owner]}/#{issue_params[:repo]}"
-  def issue_params = params.permit(:owner, :repo, :issue_number)
+  private
+
+  # By using `find_or_initialize_by`, we avoid creating a new `WorkingDocument`
+  # record until the user actually makes an edit to the document. This is
+  # important because we don't want to create a record for every issue that is
+  # opened in the repo, only the ones that are actually being edited.
+  #
+  # We can explore other options for cost saving in the future ideally we don't
+  # need to persist the document body in the database at all.
+  #
+  # * The minimum viable solution is to use a background job to delete old
+  #   `WorkingDocument` records.
+  #
+  # * The ideal solution is to not need to persist the document body at all.
+  #   * We can send the document body to the server to render the preview card.
+  #   * We can use `ActionCable` to broadcast the `ChangeSet` to all connected
+  #     clients so they can update their codemirror editors.
+  #   * We could also use `ActionCable` to broadcast the updated preview card.
+  #   * :warn: Updates could be lost on page refresh, need to investigate local
+  #     storage options.
+  #   * Newly connected clients would need to fetch the latest document body
+  #     state via `ActionCable` from another connected client.
+  #   * When multiple client rejoin with different copies of the body we need
+  #     to generate and resolve/surface merge conflicts.
+  #
+  # Using the ChangeSet to update comment positions is the trickiest part of
+  # this application so I'm going to focus on that first. This comment should
+  # be sufficient documentation for next steps in this problem domain.
+  def set_document
+    @document = WorkingDocument.find_or_initialize_by(issue_params) do |doc|
+      issue = Issue.new(github.issue(repo, issue_params[:issue_number]))
+      doc.issue_title = issue.title
+      doc.pull = issue.pull?
+      doc.body = issue.body.gsub("\r", "")
+    end
+  end
+
+  def repo = "#{issue_params[:owner]}/#{issue_params[:repo_name]}"
+  def issue_params = params.permit(:owner, :repo_name, :issue_number)
+  def document_params = params.permit(:from_a, :to_a, :from_b, :to_b, :inserted)
+
+  def change_set
+    ChangeSet.new(
+      document_params[:from_a].to_i,
+      document_params[:to_a].to_i,
+      document_params[:from_b].to_i,
+      document_params[:to_b].to_i,
+      document_params[:inserted],
+    )
+  end
 end

--- a/app/javascript/codemirror/stimulus_plugin.js
+++ b/app/javascript/codemirror/stimulus_plugin.js
@@ -1,0 +1,29 @@
+import {ViewPlugin} from "@codemirror/view"
+
+export default function(controller) {
+  return ViewPlugin.fromClass(class {
+    constructor(view) {
+      this.view = view;
+      this.controller = controller;
+    }
+
+    update(update) {
+      if (update.docChanged) {
+        update.changes.iterChanges(
+          (fromA, toA, fromB, toB, inserted) => {
+            this.controller.sync({
+              fromA: fromA,
+              toA: toA,
+              fromB: fromB,
+              toB: toB,
+              inserted: inserted,
+            })
+          },
+          true,
+        )
+      }
+    }
+
+    destroy() {}
+  })
+}

--- a/app/javascript/controllers/editor_controller.js
+++ b/app/javascript/controllers/editor_controller.js
@@ -1,0 +1,46 @@
+import { Controller } from "@hotwired/stimulus"
+
+import {EditorState} from "@codemirror/state"
+import {EditorView, lineNumbers, keymap} from "@codemirror/view"
+import {defaultKeymap} from "@codemirror/commands"
+
+import StimulusPlugin from "../codemirror/stimulus_plugin"
+
+// Connects to data-controller="editor"
+export default class extends Controller {
+  static targets = [
+    "source",
+    "fromA",
+    "toA",
+    "fromB",
+    "toB",
+    "inserted",
+    "submit",
+  ]
+
+  connect() {
+    let startState = EditorState.create({
+      doc: this.sourceTarget.value,
+      extensions: [
+        keymap.of(defaultKeymap),
+        lineNumbers(),
+        EditorView.lineWrapping,
+        StimulusPlugin(this),
+      ]
+    })
+
+    this.view = new EditorView({
+      state: startState,
+      parent: this.element,
+    })
+  }
+
+  sync(codemirrorChange) {
+    this.fromATarget.value = codemirrorChange.fromA;
+    this.toATarget.value = codemirrorChange.toA;
+    this.fromBTarget.value = codemirrorChange.fromB;
+    this.toBTarget.value = codemirrorChange.toB;
+    this.insertedTarget.value = codemirrorChange.inserted.text.join("\n");
+    this.submitTarget.click();
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -3,3 +3,6 @@
 // ./bin/rails generate stimulus controllerName
 
 import { application } from "./application"
+
+import EditorController from "./editor_controller"
+application.register("editor", EditorController)

--- a/app/lib/markdown_renderer.rb
+++ b/app/lib/markdown_renderer.rb
@@ -1,0 +1,33 @@
+require "rouge/plugins/redcarpet"
+
+module MarkdownRenderer
+  class Renderer < Redcarpet::Render::HTML
+    include Rouge::Plugins::Redcarpet
+
+    def rouge_formatter(lexer)
+      Rouge::Formatters::HTMLLegacy.new(
+        css_class: "line-numbers language-#{lexer.tag.strip}",
+      )
+    end
+  end
+
+  GithubFlavouredMarkdown = Redcarpet::Markdown.new(
+    Renderer.new(
+      link_attributes: { target: '_blank', rel: 'noopener' }
+    ),
+    tables: true,
+    autolink: true,
+    hard_wrap: true,
+    highlight: true,
+    superscript: true,
+    strikethrough: true,
+    with_toc_data: true,
+    no_intra_emphasis: true,
+    fenced_code_blocks: true,
+    space_after_headers: false,
+  )
+
+  def self.md_to_html(content)
+    GithubFlavouredMarkdown.render(content).html_safe
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,0 +1,33 @@
+class Document
+  attr_reader :body
+
+  SAMPLE_BODY = <<~MARKDOWN
+    ## What
+
+    Logged in users can...
+
+    testing some other\r
+    \r
+    types of content\r
+    blocks.\r
+    Are these all a single paragraph?
+
+    ## Empty Card
+
+    img here
+
+    ```ruby
+    def hello
+      nil
+    end
+    ```
+  MARKDOWN
+
+  def initialize(body)
+    @body = SAMPLE_BODY
+  end
+
+  def to_html
+    MarkdownRenderer.md_to_html(body)
+  end
+end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -12,6 +12,7 @@ class Issue
     :title,
     :number,
     :state,
+    :body,
     :html_url,
     :pull_request,
     :repository_url,
@@ -24,6 +25,7 @@ class Issue
   def edit_url = html_url.delete_prefix(GITHUB_URL)
   def pull? = !!pull_request
   def open? = state == "open"
+  def document = Document.new(body, id: number)
 
   def octicon
     return "git-pull-request" if pull? && open?

--- a/app/models/working_document.rb
+++ b/app/models/working_document.rb
@@ -1,0 +1,13 @@
+class WorkingDocument < ApplicationRecord
+  def to_html = MarkdownRenderer.md_to_html(body)
+  def document_type = pull? ? "pull" : "issue"
+  def edit_url = "/#{owner}/#{repo_name}/#{document_type}/#{issue_number}"
+
+  def apply(change_set)
+    if change_set.from_a > body.length
+      body << change_set.inserted
+    else
+      body[change_set.from_a...change_set.to_a] = change_set.inserted
+    end
+  end
+end

--- a/app/views/issues/_card.html.erb
+++ b/app/views/issues/_card.html.erb
@@ -1,0 +1,5 @@
+<%= turbo_frame_tag "preview_card" do %>
+  <article class="prose">
+    <%= @document.to_html %>
+  </article>
+<% end %>

--- a/app/views/issues/edit.html.erb
+++ b/app/views/issues/edit.html.erb
@@ -1,1 +1,17 @@
-<h1 class="text-4xl"><%= @issue.title %></h1>
+<h1 class="text-4xl"><%= @document.issue_title %></h1>
+
+<div class="grid grid-cols-2 gap-4">
+  <div data-controller="editor"
+       class="border">
+    <%= form_with url: @document.edit_url do |f| %>
+      <%= f.text_area :body, value: @document.body, class: "hidden", :"data-editor-target" => "source" %>
+      <%= f.hidden_field :from_a, :"data-editor-target" => "fromA" %>
+      <%= f.hidden_field :to_a, :"data-editor-target" => "toA" %>
+      <%= f.hidden_field :from_b, :"data-editor-target" => "fromB" %>
+      <%= f.hidden_field :to_b, :"data-editor-target" => "toB" %>
+      <%= f.hidden_field :inserted, :"data-editor-target" => "inserted" %>
+      <%= f.submit class: "hidden", :"data-editor-target" => "submit" %>
+    <% end %>
+  </div>
+  <%= render "card" %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", "dracula", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   </head>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   get "auth/:provider/callback", to: "sessions#create"
   delete "/logout", to: "sessions#delete"
 
-  get ":owner/:repo/issues/:issue_number", to: "issues#edit"
-  get ":owner/:repo/pull/:issue_number", to: "issues#edit"
+  get ":owner/:repo_name/issues/:issue_number", to: "issues#edit"
+  get ":owner/:repo_name/pull/:issue_number", to: "issues#edit"
+  post ":owner/:repo_name/issues/:issue_number", to: "issues#update"
+  post ":owner/:repo_name/pull/:issue_number", to: "issues#update"
 end

--- a/db/migrate/20230220030137_create_working_documents.rb
+++ b/db/migrate/20230220030137_create_working_documents.rb
@@ -1,0 +1,16 @@
+class CreateWorkingDocuments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :working_documents do |t|
+      t.string :owner, null: false
+      t.string :repo_name, null: false
+      t.integer :issue_number, null: false
+
+      t.string :issue_title, null: false
+      t.boolean :pull, null: false
+      t.text :body, null: false, default: ""
+
+      t.timestamps
+      t.index [:owner, :repo_name, :issue_number]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,26 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2023_02_20_030137) do
+  create_table "working_documents", force: :cascade do |t|
+    t.string "owner", null: false
+    t.string "repo_name", null: false
+    t.integer "issue_number", null: false
+    t.string "issue_title", null: false
+    t.boolean "pull", null: false
+    t.text "body", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["owner", "repo_name", "issue_number"], name: "index_working_documents_on_owner_and_repo_name_and_issue_number"
+  end
+
+end

--- a/package.json
+++ b/package.json
@@ -12,5 +12,12 @@
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=assets",
     "build:css": "tailwindcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify"
+  },
+  "devDependencies": {
+    "@codemirror/commands": "^6.2.1",
+    "@codemirror/lang-markdown": "^6.1.0",
+    "@codemirror/state": "^6.2.0",
+    "@codemirror/view": "^6.9.1",
+    "@tailwindcss/typography": "^0.5.9"
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,5 +12,8 @@ module.exports = {
         'github-purple': '#8250e9'
       }
     }
-  }
+  },
+  plugins: [
+    require('@tailwindcss/typography'),
+  ]
 }

--- a/test/models/working_document_test.rb
+++ b/test/models/working_document_test.rb
@@ -1,0 +1,4 @@
+require "test_helper"
+
+class WorkingDocumentTest < ActiveSupport::TestCase
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,111 @@
 # yarn lockfile v1
 
 
+"@codemirror/autocomplete@^6.0.0":
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.4.2.tgz#938b25223bd21f97b2a6d85474643355f98b505b"
+  integrity sha512-8WE2xp+D0MpWEv5lZ6zPW1/tf4AGb358T5GWYiKEuCP8MvFfT3tH2mIF9Y2yr2e3KbHuSvsVhosiEyqCpiJhZQ==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.6.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/commands@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.2.1.tgz#ab5e979ad1458bbe395bf69ac601f461ac73cf08"
+  integrity sha512-FFiNKGuHA5O8uC6IJE5apI5rT9gyjlw4whqy4vlcX0wE/myxL6P1s0upwDhY4HtMWLOwzwsp0ap3bjdQhvfDOA==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.2.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/lang-css@^6.0.0":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-css/-/lang-css-6.0.2.tgz#b286d0226755a751f60599e1e2969d351aebbd4c"
+  integrity sha512-4V4zmUOl2Glx0GWw0HiO1oGD4zvMlIQ3zx5hXOE6ipCjhohig2bhWRAasrZylH9pRNTcl1VMa59Lsl8lZWlTzw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/css" "^1.0.0"
+
+"@codemirror/lang-html@^6.0.0":
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-html/-/lang-html-6.4.2.tgz#3c7117e45bae009bc7bc08eef8a79b5d05930d83"
+  integrity sha512-bqCBASkteKySwtIbiV/WCtGnn/khLRbbiV5TE+d9S9eQJD7BA4c5dTRm2b3bVmSpilff5EYxvB4PQaZzM/7cNw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/lang-css" "^6.0.0"
+    "@codemirror/lang-javascript" "^6.0.0"
+    "@codemirror/language" "^6.4.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.2.2"
+    "@lezer/common" "^1.0.0"
+    "@lezer/css" "^1.1.0"
+    "@lezer/html" "^1.3.0"
+
+"@codemirror/lang-javascript@^6.0.0":
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-javascript/-/lang-javascript-6.1.4.tgz#8a41f4d213e1143b4eef6f65f8b77b349aaf894c"
+  integrity sha512-OxLf7OfOZBTMRMi6BO/F72MNGmgOd9B0vetOLvHsDACFXayBzW8fm8aWnDM0yuy68wTK03MBf4HbjSBNRG5q7A==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.6.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/javascript" "^1.0.0"
+
+"@codemirror/lang-markdown@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-markdown/-/lang-markdown-6.1.0.tgz#218a6ddcd6ea25039e143058fbc95cfd82f003b4"
+  integrity sha512-HQDJg1Js19fPKKsI3Rp1X0J6mxyrRy2NX6+Evh0+/jGm6IZHL5ygMGKBYNWKXodoDQFvgdofNRG33gWOwV59Ag==
+  dependencies:
+    "@codemirror/lang-html" "^6.0.0"
+    "@codemirror/language" "^6.3.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/markdown" "^1.0.0"
+
+"@codemirror/language@^6.0.0", "@codemirror/language@^6.3.0", "@codemirror/language@^6.4.0", "@codemirror/language@^6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.6.0.tgz#2204407174a38a68053715c19e28ad61f491779f"
+  integrity sha512-cwUd6lzt3MfNYOobdjf14ZkLbJcnv4WtndYaoBkbor/vF+rCNguMPK0IRtvZJG4dsWiaWPcK8x1VijhvSxnstg==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+    style-mod "^4.0.0"
+
+"@codemirror/lint@^6.0.0":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.1.1.tgz#b30741e714a43a11cb78feb2c220b4971ad175f3"
+  integrity sha512-e+M543x0NVHGayNHQzLP4XByJsvbu/ojY6+0VF2Y4Uu66Rt1nADuxNflZwECLf7gS009smIsptSUa6bUj/U/rw==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    crelt "^1.0.5"
+
+"@codemirror/state@^6.0.0", "@codemirror/state@^6.1.4", "@codemirror/state@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.2.0.tgz#a0fb08403ced8c2a68d1d0acee926bd20be922f2"
+  integrity sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA==
+
+"@codemirror/view@^6.0.0", "@codemirror/view@^6.2.2", "@codemirror/view@^6.6.0", "@codemirror/view@^6.9.1":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.9.1.tgz#2ce4c528974b6172a5a4a738b7b0a0f04a4c1140"
+  integrity sha512-bzfSjJn9dAADVpabLKWKNmMG4ibyTV2e3eOGowjElNPTdTkSbi6ixPYHm2u0ADcETfKsi2/R84Rkmi91dH9yEg==
+  dependencies:
+    "@codemirror/state" "^6.1.4"
+    style-mod "^4.0.0"
+    w3c-keyname "^2.2.4"
+
 "@esbuild/android-arm64@0.17.7":
   version "0.17.7"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.17.7.tgz#7d22b442815624423de5541545401e12a8d474d8"
@@ -130,6 +235,58 @@
   resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.2.5.tgz#2d9d6bde8a9549c3aea8970445ade16ffd56719a"
   integrity sha512-o5PByC/mWkmTe4pWnKrixhPECJUxIT/NHtxKqjq7n9Fj6JlNza1pgxdTCJVIq+PI0j95U+7mA3N4n4A/QYZtZQ==
 
+"@lezer/common@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.0.2.tgz#8fb9b86bdaa2ece57e7d59e5ffbcb37d71815087"
+  integrity sha512-SVgiGtMnMnW3ActR8SXgsDhw7a0w0ChHSYAyAUxxrOiJ1OqYWEKk/xJd84tTSPo1mo6DXLObAJALNnd0Hrv7Ng==
+
+"@lezer/css@^1.0.0", "@lezer/css@^1.1.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@lezer/css/-/css-1.1.1.tgz#c36dcb0789317cb80c3740767dd3b85e071ad082"
+  integrity sha512-mSjx+unLLapEqdOYDejnGBokB5+AiJKZVclmud0MKQOKx3DLJ5b5VTCstgDDknR6iIV4gVrN6euzsCnj0A2gQA==
+  dependencies:
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/highlight@^1.0.0", "@lezer/highlight@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-1.1.3.tgz#bf5a36c2ee227f526d74997ac91f7777e29bd25d"
+  integrity sha512-3vLKLPThO4td43lYRBygmMY18JN3CPh9w+XS2j8WC30vR4yZeFG4z1iFe4jXE43NtGqe//zHW5q8ENLlHvz9gw==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
+"@lezer/html@^1.3.0":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@lezer/html/-/html-1.3.2.tgz#28aa75e8d8856397512525a9fe3da2a033901db8"
+  integrity sha512-LKGyDdqqDugXR/lKM9FwaKEfMerbZ/aqvhLf0P1FLLK/pVP7wKHXGcg6g3cJ7ckvFidn0tXA8jioG0irVsCBAQ==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/javascript@^1.0.0":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@lezer/javascript/-/javascript-1.4.1.tgz#97a15042c76b5979af6a069fac83cf6485628cbf"
+  integrity sha512-Hqx36DJeYhKtdpc7wBYPR0XF56ZzIp0IkMO/zNNj80xcaFOV4Oj/P7TQc/8k2TxNhzl7tV5tXS8ZOCPbT4L3nA==
+  dependencies:
+    "@lezer/highlight" "^1.1.3"
+    "@lezer/lr" "^1.3.0"
+
+"@lezer/lr@^1.0.0", "@lezer/lr@^1.3.0":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.3.3.tgz#0ac6c889f1235874f33c45a1b9785d7054f60708"
+  integrity sha512-JPQe3mwJlzEVqy67iQiiGozhcngbO8QBgpqZM6oL1Wj/dXckrEexpBLeFkq0edtW5IqnPRFxA24BHJni8Js69w==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
+"@lezer/markdown@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@lezer/markdown/-/markdown-1.0.2.tgz#8c804a9f6fe1ccca4a20acd2fd9fbe0fae1ae178"
+  integrity sha512-8CY0OoZ6V5EzPjSPeJ4KLVbtXdLBd8V6sRCooN5kHnO28ytreEGTyrtU/zUwo/XLRzGr/e1g44KlzKi3yWGB5A==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+    "@lezer/highlight" "^1.0.0"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -155,6 +312,16 @@
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.4.tgz#70a3ca56809f7aaabb80af2f9c01ae51e1a8ed41"
   integrity sha512-tz4oM+Zn9CYsvtyicsa/AwzKZKL+ITHWkhiu7x+xF77clh2b4Rm+s6xnOgY/sGDWoFWZmtKsE95hxBPkgQQNnQ==
+
+"@tailwindcss/typography@^0.5.9":
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.9.tgz#027e4b0674929daaf7c921c900beee80dbad93e8"
+  integrity sha512-t8Sg3DyynFysV9f4JDOVISGsjazNb48AeIYQwcL+Bsq5uf4RYL75C1giZ43KISjeDGBaTN3Kxh7Xj/vRSMJUUg==
+  dependencies:
+    lodash.castarray "^4.4.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.merge "^4.6.2"
+    postcss-selector-parser "6.0.10"
 
 acorn-node@^1.8.2:
   version "1.8.2"
@@ -251,6 +418,11 @@ color-name@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+crelt@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.5.tgz#57c0d52af8c859e354bace1883eb2e1eb182bb94"
+  integrity sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -416,6 +588,21 @@ lilconfig@^2.0.5, lilconfig@^2.0.6:
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.6.tgz#32a384558bd58af3d4c6e077dd1ad1d397bc69d4"
   integrity sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==
 
+lodash.castarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz#c02513515e309daddd4c24c60cfddcf5976d9115"
+  integrity sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
 merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
@@ -510,6 +697,14 @@ postcss-nested@6.0.0:
   dependencies:
     postcss-selector-parser "^6.0.10"
 
+postcss-selector-parser@6.0.10:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
 postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.11:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz#2e41dc39b7ad74046e1615185185cd0b17d0c8dc"
@@ -582,6 +777,11 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
+style-mod@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.0.0.tgz#97e7c2d68b592975f2ca7a63d0dd6fcacfe35a01"
+  integrity sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==
+
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
@@ -635,6 +835,11 @@ util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+w3c-keyname@^2.2.4:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.6.tgz#8412046116bc16c5d73d4e612053ea10a189c85f"
+  integrity sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==
 
 xtend@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## What

I used a the `codemirror` package as the markdown editor with stimulus to trigger form updates with the change sets. The change sets are applied to a copy of the data stored in the `WorkingDocument` record. Then the markdown is rendered to HTML and Turbo updates the preview card on the clientside.

By using `find_or_initialize_by`, we avoid creating a new `WorkingDocument` record until the user actually makes an edit to the document. This is important because we don't want to create a record for every issue that is opened in the repo, only the ones that are actually being edited.

We can explore other options for cost saving in the future, ideally we don't need to persist the document body in the database at all.

* The minimum viable solution is to use a background job to delete old `WorkingDocument` records.

* The ideal solution is to not need to persist the document body at all.
  * We can send the document body to the server to render the preview card.
  * We can use `ActionCable` to broadcast the `ChangeSet` to all connected clients so they can update their codemirror editors.
  * We could also use `ActionCable` to broadcast the updated preview card.
  * :warn: Updates could be lost on page refresh, need to investigate local storage options.
  * Newly connected clients would need to fetch the latest document body state via `ActionCable` from another connected client.
  * When multiple client rejoin with different copies of the body we need to generate and resolve/surface merge conflicts.

Using the ChangeSet to update comment positions is the trickiest part of this application so I'm going to focus on that first. This comment should be sufficient documentation for next steps in this problem domain.

## Screenshot

<img width="1908" alt="Screen Shot 2023-02-19 at 11 26 30 PM" src="https://user-images.githubusercontent.com/6456191/220009521-0f2aa20d-23d3-43d7-ba6f-e0111cb801c9.png">
